### PR TITLE
Fix another date bug

### DIFF
--- a/gmailsorter/base/message.py
+++ b/gmailsorter/base/message.py
@@ -11,7 +11,9 @@ def email_date_converter(email_date):
         email_date = " ".join(email_date.split()[:-1])
     if email_date[-1].isalpha():
         email_date = email_date[:-1]
-    if email_date[:3].isalpha() and email_date[-3] != ":":
+    if email_date[:3].isalpha() and email_date[-3] != ":" and email_date[-6] == "_":
+        return datetime.strptime(email_date.split(".")[0], "%a, %d %b %Y %H:%M:%S %z")
+    elif email_date[:3].isalpha() and email_date[-3] != ":":
         return datetime.strptime(email_date, "%a, %d %b %Y %H:%M:%S %z")
     elif email_date[-3] == ":":
         return datetime.strptime(email_date, "%a, %d %b %Y %H:%M:%S")

--- a/gmailsorter/google/message.py
+++ b/gmailsorter/google/message.py
@@ -24,7 +24,7 @@ def get_email_dict(message):
     try:
         return Message(message_dict=message).to_dict()
     except ValueError as e:
-        print(message, e.message)
+        print(message, str(e))
         return None
 
 


### PR DESCRIPTION
Examples are `'Mon, 10 Jul 2023 01:40:54 +0000.9285_32569'` and `'Sat, 08 Jul 2023 21:13:43 +0000.81776_57079'`. For the moment I ignore the part after the dot, as I cannot really make sense of it. 